### PR TITLE
Urgent hotfix Memolog::SentryExtension

### DIFF
--- a/lib/memolog/sentry_extension.rb
+++ b/lib/memolog/sentry_extension.rb
@@ -18,7 +18,7 @@ module Memolog::SentryExtension
 
     def set_extras_memolog!
       return unless get_current_scope
-      set_extras(Memolog.config.sentry_key => Memolog.dump)
+      set_extras(memolog: Memolog.dump)
     end
   end
 end

--- a/lib/memolog/version.rb
+++ b/lib/memolog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Memolog
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
- Forget to remove old config option.
- Version bump.