### PR TITLE
Move Init to module. Docs for Sentry using.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    memolog (0.3.3)
+    memolog (0.3.4)
       logger (~> 1.4.3)
       securerandom (~> 0.1.0)
 

--- a/README.md
+++ b/README.md
@@ -27,20 +27,27 @@ Use this example during application initialization process (this example impleme
 Memolog.configure do |config|
   config.debug = false
   config.formatter = ::Memolog::Formatter.new
-  config.initializers = %i[rails sidekiq]
+  config.middlewares = %i[rails sidekiq]
   config.log_size_limit = 50_000
   config.uuid_callable = -> { SecureRandom.uuid }
 end
 
-Memolog.init!
+Memolog.init_middlewares!
 ```
 
 Available options are:
 - `debug` - set it to true if you need to leave Memolog.dump result outside `Memolog.run {}` block.
 - `formatter` - setup your own formatter.
-- `initializers` - define here what you want to initialize in `#init!` call.
+- `middlewares` - define here what you want to initialize in `#init_middlewares!` call.
 - `log_size_limit` - max log length in `#dump`.
 - `uuid_callable` - Memolog add unique value to logs, here you can redefine uuid generation.
+
+If you want to apply Sentry monkey patch that call `Memolog.dump` before `Sentry.capture_exception`
+and `Sentry.capture_message` you can implement it via this code:
+
+```ruby
+Sentry.prepend(Memolog::SentryExtension)
+```
 
 ## Usage
 

--- a/lib/memolog.rb
+++ b/lib/memolog.rb
@@ -6,9 +6,9 @@ require "stringio"
 
 require "memolog/version"
 require "memolog/config"
-require "memolog/extension"
 require "memolog/formatter"
 require "memolog/init"
+require "memolog/logger_extension"
 require "memolog/rails_middleware"
 require "memolog/sentry_extension"
 require "memolog/sidekiq_middleware"
@@ -29,7 +29,7 @@ module Memolog
   end
 
   def extend_logger(other_logger)
-    other_logger.extend(Memolog::Extension)
+    other_logger.extend(Memolog::LoggerExtension)
     other_logger.formatter = config.formatter
   end
 

--- a/lib/memolog.rb
+++ b/lib/memolog.rb
@@ -24,8 +24,8 @@ module Memolog
     yield(config) if block_given?
   end
 
-  def init!
-    Memolog::Init.new.call
+  def init_middlewares!
+    Memolog::Init.init_middlewares!
   end
 
   def extend_logger(other_logger)

--- a/lib/memolog/config.rb
+++ b/lib/memolog/config.rb
@@ -3,14 +3,14 @@
 Memolog::Config = Struct.new(
   :debug,
   :formatter,
-  :initializers,
+  :middlewares,
   :log_size_limit,
   :uuid_callable,
 ) do
   def initialize
     self.debug = false
     self.formatter = ::Memolog::Formatter.new
-    self.initializers = %i[rails sidekiq]
+    self.middlewares = %i[rails sidekiq]
     self.log_size_limit = 50_000
     self.uuid_callable = -> { SecureRandom.uuid }
   end

--- a/lib/memolog/init.rb
+++ b/lib/memolog/init.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-class Memolog::Init
-  def call
+module Memolog::Init
+  extend self
+
+  def init_middlewares!
     init_rails_middleware!
     init_sidekiq_middleware!
   end
 
-  private
-
   def init_rails_middleware!
-    return unless Memolog.config.initializers.include?(:rails)
+    return unless Memolog.config.middlewares.include?(:rails)
     return unless Object.const_defined?("Rails")
     return if Object.const_defined?("Sidekiq") && Sidekiq.server?
 
@@ -17,7 +17,7 @@ class Memolog::Init
   end
 
   def init_sidekiq_middleware!
-    return unless Memolog.config.initializers.include?(:sidekiq)
+    return unless Memolog.config.middlewares.include?(:sidekiq)
     return unless Object.const_defined?("Sidekiq")
 
     Sidekiq.configure_server do |config|

--- a/lib/memolog/logger_extension.rb
+++ b/lib/memolog/logger_extension.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Memolog::Extension
+module Memolog::LoggerExtension
   def add(*args, &block)
     Memolog.logger.log(*args, &block)
     super

--- a/lib/memolog/version.rb
+++ b/lib/memolog/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Memolog
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end

--- a/spec/memolog_spec.rb
+++ b/spec/memolog_spec.rb
@@ -4,15 +4,15 @@ describe Memolog do
   describe "#configure" do
     it "can change configuration" do
       described_class.configure do |config|
-        config.initializers = []
+        config.middlewares = []
         config.log_size_limit = 1
       end
 
-      expect(described_class.config.initializers).to eq([])
+      expect(described_class.config.middlewares).to eq([])
       expect(described_class.config.log_size_limit).to eq(1)
 
       described_class.configure do |config|
-        config.initializers = %i[rails sentry sidekiq]
+        config.middlewares = %i[rails sidekiq]
         config.log_size_limit = 50_000
       end
     end
@@ -76,7 +76,7 @@ end
 describe Memolog::Init do
   describe "#init_rails_middleware!" do
     it "insert middleware to Rails.application" do
-      make_rails_app { described_class.new.send(:init_rails_middleware!) }
+      make_rails_app { described_class.init_rails_middleware! }
       expect(Rails.application.middleware[0]).to eq(Memolog::RailsMiddleware)
     end
   end
@@ -87,7 +87,7 @@ describe Memolog::Init do
     let(:queue) { double(:queue) }
 
     it "insert middleware to Sidekiq" do
-      described_class.new.send(:init_sidekiq_middleware!)
+      described_class.init_sidekiq_middleware!
       expect(Memolog).to receive(:run)
 
       Memolog::SidekiqMiddleware.new.call(worker, job, queue)


### PR DESCRIPTION
- Config option middlewares instead of initializers.
- Better class naming for logger extension.
- Docs for Sentry using.
- Specs